### PR TITLE
Errors actually live in a single word now.

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -55,8 +55,8 @@ fn main() {
     let _ = test();
     match bubble() {
         Ok(x) => println!("Produced {}", x),
-        Err(ref err) => {
-            print_traceback(err);
+        Err(box err) => {
+            print_traceback(&err);
             match err.file {
                 Some(ref f) => println!("filename = {}", f.display()),
                 None => {}


### PR DESCRIPTION
Unfortunately Rust does not apply the null pointer optimization to boxes within structs, so in order to make Result<(), Failure<E>> one word you have to actually leave the Box outside the struct (previously, we were using Option<Box<T>> which eliminates this possibility, but this PR changes things so that the Option lives inside the Box).  The change basically means the user has to write box err instead of ref err (box ref err results in essentially the same semantics as before, but I wasn't sure which was better to put in the example document).
